### PR TITLE
Use character ID instead of nickname, save changed names, and change API.

### DIFF
--- a/schema/setup.sql
+++ b/schema/setup.sql
@@ -8,14 +8,13 @@ CREATE TABLE `accounts` (
 ) ENGINE=InnoDB;
 
 CREATE TABLE `characters` (
-    `id` INT(11) NOT NULL AUTO_INCREMENT,
-    `account_id` int(11) NOT NULL,
-    `nick` VARCHAR(40) NOT NULL,
+    `id` INT(11) NOT NULL,
+    `account_id` INT(11) NOT NULL,
     `first` VARCHAR(255) NOT NULL,
+    `nick` VARCHAR(255) NOT NULL,
     `last` VARCHAR(255) NOT NULL,
     `first_write` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE (`nick`)
+    PRIMARY KEY (`id`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE `properties` (

--- a/schema/update-0.1.sql
+++ b/schema/update-0.1.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `characters`
+    CHANGE `id` `id` INT(11) NOT NULL,
+    CHANGE `nick` `nick` VARCHAR(255) NOT NULL AFTER `first`,
+    DROP INDEX nick;

--- a/src/Actions/SaveAccount.php
+++ b/src/Actions/SaveAccount.php
@@ -3,19 +3,22 @@
 namespace Incertitude\SWLRP\Actions;
 
 use Incertitude\SWLRP\Action;
+use Incertitude\SWLRP\Models\Account;
 
+/**
+ * @method Account getModel()
+ */
 class SaveAccount extends Action {
     const MODEL_NAME = 'Account';
     public function execute() {
-        $name = ucwords($this->getData(0));
-        $accountId = $this->getModel()->getLoginData($name)['account_id'] ?? null;
+        $characterId = (int)$this->getData(0);
+        $names = array_values($this->getNameData());
+        $accountId = $this->getModel()->getLoginData($characterId)['account_id'] ?? null;
         $password = $this->getData('password');
         if (!isset($accountId)) {
             $passwordHash = password_hash($password, PASSWORD_DEFAULT);
-            $accountId = $this->getModel()->createAccount(
-                $name, $passwordHash, ucwords($this->getData(1)) ?: '', ucwords($this->getData(2)) ?: ''
-            );
+            $accountId = $this->getModel()->createAccount($passwordHash, $characterId, ...$names);
         }
-        $this->getSession()->login($name, $password);
+        $this->getSession()->login($characterId, $password);
     }
 }

--- a/src/Actions/SaveAccount.php
+++ b/src/Actions/SaveAccount.php
@@ -18,6 +18,8 @@ class SaveAccount extends Action {
         if (!isset($accountId)) {
             $passwordHash = password_hash($password, PASSWORD_DEFAULT);
             $accountId = $this->getModel()->createAccount($passwordHash, $characterId, ...$names);
+        } else {
+            $this->getModel()->setCharacterName($accountId, $characterId, ...$names);
         }
         $this->getSession()->login($characterId, $password);
     }

--- a/src/Actions/SaveAccount.php
+++ b/src/Actions/SaveAccount.php
@@ -16,6 +16,6 @@ class SaveAccount extends Action {
                 $name, $passwordHash, ucwords($this->getData(1)) ?: '', ucwords($this->getData(2)) ?: ''
             );
         }
-        $this->getSession()->login($name, $password, (bool)$this->getData('autologin'));
+        $this->getSession()->login($name, $password);
     }
 }

--- a/src/Actions/SaveProfile.php
+++ b/src/Actions/SaveProfile.php
@@ -3,12 +3,16 @@
 namespace Incertitude\SWLRP\Actions;
 
 use Incertitude\SWLRP\Action;
+use Incertitude\SWLRP\Models\Profile;
 
+/**
+ * @method Profile getModel()
+ */
 class SaveProfile extends Action {
     public function execute() {
-        $name = $this->getSession()->getNickLoggedIn();
+        $id = $this->getSession()->getCharacterId();
         $this->getModel()->saveProperties(
-            $name,
+            $id,
             $this->getData()
         );
     }

--- a/src/Actions/UpdatePassword.php
+++ b/src/Actions/UpdatePassword.php
@@ -4,17 +4,21 @@ namespace Incertitude\SWLRP\Actions;
 
 use Incertitude\SWLRP\Action;
 use Incertitude\SWLRP\Exceptions\PwChangeFailed;
+use Incertitude\SWLRP\Models\Account;
 
+/**
+ * @method Account getModel()
+ */
 class UpdatePassword extends Action {
     const MODEL_NAME = 'Account';
     public function execute() {
-        $name = $this->getSession()->getNickLoggedIn();
-        if (!$this->getSession()->checkPassword($name, $this->getData('password') ?: '')) {
+        $id = $this->getSession()->getCharacterId();
+        if (!$this->getSession()->checkPassword($id, $this->getData('password') ?: '')) {
             http_response_code(401);
             exit;
         }
         $password = $this->getData('pwnew') ?: '';
         $passwordHash = password_hash($password, PASSWORD_DEFAULT);
-        $this->getModel()->setPasswordHash($name, $passwordHash);
+        $this->getModel()->setPasswordHash($id, $passwordHash);
     }
 }

--- a/src/Application.php
+++ b/src/Application.php
@@ -26,8 +26,8 @@ class Application {
             $get = $uriParts + $get;
             $post = $uriParts + $post;
         }
-        $this->get = $get;
-        $this->post = $post;
+        $this->get = array_map('urldecode', $get);
+        $this->post = array_map('urldecode', $post);
         $this->config = new Config($root . '/config/config.yml');
         $this->pdo = new \PDO(
             $this->config->get('DB', 'dsn'),

--- a/src/Exceptions/IsLoggedIn.php
+++ b/src/Exceptions/IsLoggedIn.php
@@ -2,6 +2,6 @@
 
 namespace Incertitude\SWLRP\Exceptions;
 
-class AutoLogin extends RedirectError {
+class IsLoggedIn extends RedirectError {
     const LOCATION = '/edit';
 }

--- a/src/IOComponent.php
+++ b/src/IOComponent.php
@@ -15,6 +15,13 @@ abstract class IOComponent {
     protected function getData($key=null) {
         return isset($key) ? $this->data[$key] ?? null : $this->data;
     }
+    protected function getNameData(): array {
+        $names = [];
+        foreach (['first', 'nick', 'last'] as $type) {
+            $names[$type] = ucwords($this->getData($type) ?: '');
+        }
+        return $names;
+    }
     protected function getModel(): Model {
         return $this->model;
     }

--- a/src/Model.php
+++ b/src/Model.php
@@ -28,11 +28,14 @@ abstract class Model {
         array_unshift($keys, 'Models', (new \ReflectionClass($this))->getShortName());
         return $this->config->get(...$keys);
     }
-    private function populateData(&$data) {
+    private function populateData(&$data, $level = 0) {
         foreach ($data as $key => &$value) {
             if (is_array($value)) {
-                $this->populateData($value);
-                if (!is_numeric($key) && !in_array($key, ['texts', 'properties'])) {
+                if (0 === $level) {
+                    $value += ['texts' => [], 'properties' => []];
+                }
+                $this->populateData($value, $level + 1);
+                if (!is_numeric($key) && 1 !== $level) {
                     $value += [
                         'name' => $key,
                         'title' => ucwords($key),

--- a/src/Models/Account.php
+++ b/src/Models/Account.php
@@ -67,4 +67,11 @@ QUERY;
         }
         return $result;
     }
+    public function setCharacterName(int $accountId, int $characterId, string $first, string $nick, string $last): bool {
+        $statement = $this->getConnection()->prepare(self::Q_SAVE_NAME);
+        return $statement->execute([
+            ':characterId' => $characterId, ':account_id' => $accountId,
+            ':first' => $first, ':nick' => $nick, ':last' => $last
+        ]);
+    }
 }

--- a/src/Models/Account.php
+++ b/src/Models/Account.php
@@ -10,40 +10,43 @@ class Account extends Model {
 SELECT `account_id`, `password_hash`, `session_hash`
 FROM `accounts` AS `a`
 INNER JOIN `characters` AS `c` ON `c`.`account_id` = `a`.`id`
-WHERE `nick` = :nick
+WHERE `c`.`id` = :characterId
 QUERY;
     const Q_SET_PASSWORD_HASH = <<<'QUERY'
 UPDATE `accounts` AS `a`
 INNER JOIN `characters` AS `c` ON `c`.`account_id` = `a`.`id`
 SET `password_hash` = :hash
-WHERE `nick` = :nick
+WHERE `c`.`id` = :characterId
 QUERY;
     const Q_CREATE_ACCOUNT = <<<'QUERY'
 INSERT INTO `accounts` (`password_hash`)
 VALUES (:hash)
 QUERY;
     const Q_SAVE_NAME = <<<'QUERY'
-INSERT INTO `characters`(`account_id`, `nick`, `first`, `last`)
-VALUES (:account_id, :nick, :first, :last)
+INSERT INTO `characters`(`id`, `account_id`, `first`, `nick`, `last`)
+VALUES (:characterId, :account_id, :first, :nick, :last)
 ON DUPLICATE KEY UPDATE
-     `account_id` = VALUES(`account_id`), `first` = VALUES(`first`), `last` = VALUES(`last`)
+    `account_id` = VALUES(`account_id`),
+    `first` = IF(VALUES(`first`) = '', `first`, VALUES(`first`)),
+    `nick`  = IF(VALUES(`nick`)  = '', `nick`,  VALUES(`nick`)),
+    `last`  = IF(VALUES(`last`)  = '', `last`,  VALUES(`last`))
 QUERY;
-    public function getLoginData(string $nick): array {
+    public function getLoginData(int $characterId): array {
         $statement = $this->getConnection()->prepare(self::Q_GET_LOGIN_DATA);
-        $statement->execute([':nick' => $nick]);
+        $statement->execute([':characterId' => $characterId]);
         $result = $statement->fetch();
         $statement->closeCursor();
         return $result ?: [];
     }
-    public function setPasswordHash(string $nick, string $sessionHash): bool {
+    public function setPasswordHash(int $characterId, string $sessionHash): bool {
         return $this->getConnection()->prepare(self::Q_SET_PASSWORD_HASH)
-            ->execute([':nick' => $nick, ':hash' => $sessionHash]);
+            ->execute([':characterId' => $characterId, ':hash' => $sessionHash]);
     }
-    public function isRegistered(string $nick): bool {
-        $data = $this->getLoginData($nick);
+    public function isRegistered(int $characterId): bool {
+        $data = $this->getLoginData($characterId);
         return !empty($data);
     }
-    public function createAccount(string $nick, string $passwordHash, string $first, string $last): int {
+    public function createAccount(string $passwordHash, int $characterId, string $first, string $nick, string $last): int {
         $this->getConnection()->beginTransaction();
         try {
             $this->getConnection()->prepare(self::Q_CREATE_ACCOUNT)
@@ -51,7 +54,8 @@ QUERY;
             $accountId = $this->getConnection()->lastInsertId();
             $statement = $this->getConnection()->prepare(self::Q_SAVE_NAME);
             $result = $statement->execute([
-                ':account_id' => $accountId, ':nick' => $nick, ':first' => $first, ':last' => $last
+                ':characterId' => $characterId, ':account_id' => $accountId,
+                ':first' => $first, ':nick' => $nick, ':last' => $last
             ]);
             if (!$accountId || !$result) {
                 throw new RegistrationFailed();

--- a/src/Models/Account.php
+++ b/src/Models/Account.php
@@ -12,22 +12,10 @@ FROM `accounts` AS `a`
 INNER JOIN `characters` AS `c` ON `c`.`account_id` = `a`.`id`
 WHERE `nick` = :nick
 QUERY;
-    const Q_GET_AUTOLOGIN_NICK = <<<'QUERY'
-SELECT `nick`
-FROM `characters` AS `c`
-INNER JOIN `accounts` AS `a` ON `c`.`account_id` = `a`.`id`
-WHERE `session_hash` = :hash
-QUERY;
     const Q_SET_PASSWORD_HASH = <<<'QUERY'
 UPDATE `accounts` AS `a`
 INNER JOIN `characters` AS `c` ON `c`.`account_id` = `a`.`id`
 SET `password_hash` = :hash
-WHERE `nick` = :nick
-QUERY;
-    const Q_SET_AUTOLOGIN_HASH = <<<'QUERY'
-UPDATE `accounts` AS `a`
-INNER JOIN `characters` AS `c` ON `c`.`account_id` = `a`.`id`
-SET `session_hash` = :hash
 WHERE `nick` = :nick
 QUERY;
     const Q_CREATE_ACCOUNT = <<<'QUERY'
@@ -49,17 +37,6 @@ QUERY;
     }
     public function setPasswordHash(string $nick, string $sessionHash): bool {
         return $this->getConnection()->prepare(self::Q_SET_PASSWORD_HASH)
-            ->execute([':nick' => $nick, ':hash' => $sessionHash]);
-    }
-    public function getAutoLoginNick(string $sessionHash): string {
-        $statement = $this->getConnection()->prepare(self::Q_GET_AUTOLOGIN_NICK);
-        $statement->execute([':hash' => $sessionHash]);
-        $result = $statement->fetch()['nick'] ?? '';
-        $statement->closeCursor();
-        return $result;
-    }
-    public function setAutoLoginHash(string $nick, string $sessionHash): bool {
-        return $this->getConnection()->prepare(self::Q_SET_AUTOLOGIN_HASH)
             ->execute([':nick' => $nick, ':hash' => $sessionHash]);
     }
     public function isRegistered(string $nick): bool {

--- a/src/Session.php
+++ b/src/Session.php
@@ -16,12 +16,6 @@ class Session {
         ini_set('session.cookie_httponly', true);
         ini_set('session.cookie_secure', $useSecureCookies);
         session_start();
-        if (!isset($_SESSION['nick']) && isset($_COOKIE['autologin'])) {
-            $nick = $this->model->getAutoLoginNick($_COOKIE['autologin']);
-            if (!empty($nick)) {
-                $_SESSION['nick'] = $nick;
-            }
-        }
     }
     public function getNickLoggedIn(): string {
         return $_SESSION['nick'] ?? '';
@@ -38,22 +32,11 @@ class Session {
         $data = $this->model->getLoginData($nick);
         return password_verify($password, $data['password_hash'] ?? '');
     }
-    public function login(string $nick, string $password, bool $autoLogin): bool {
+    public function login(string $nick, string $password): bool {
         if (!$this->checkPassword($nick, $password)) {
             return false;
         }
         $_SESSION['nick'] = $nick;
-        $sessionHash = '';
-        if ($autoLogin) {
-            $sessionHash = hash('sha512', "$nick.$password." . microtime());
-            setcookie(
-                'autologin', $sessionHash, (new \DateTime('+ 1 month'))->getTimestamp(),
-                '/', '', $this->useSecureCookies, true
-            );
-        } else {
-            setcookie('autologin', '', time() - 3600);
-        }
-        $this->model->setAutoLoginHash($nick, $sessionHash);
         return true;
     }
 }

--- a/src/Session.php
+++ b/src/Session.php
@@ -17,26 +17,26 @@ class Session {
         ini_set('session.cookie_secure', $useSecureCookies);
         session_start();
     }
-    public function getNickLoggedIn(): string {
-        return $_SESSION['nick'] ?? '';
+    public function getCharacterId(): int {
+        return $_SESSION['characterId'] ?? 0;
     }
     public function isLoggedIn() {
-        return isset($_SESSION['nick']);
+        return isset($_SESSION['characterId']);
     }
     public function assertLoggedIn() {
         if (!$this->isLoggedIn()) {
             throw new NotLoggedIn();
         }
     }
-    public function checkPassword(string $nick, string $password): bool {
-        $data = $this->model->getLoginData($nick);
+    public function checkPassword(int $characterId, string $password): bool {
+        $data = $this->model->getLoginData($characterId);
         return password_verify($password, $data['password_hash'] ?? '');
     }
-    public function login(string $nick, string $password): bool {
-        if (!$this->checkPassword($nick, $password)) {
+    public function login(int $characterId, string $password): bool {
+        if (!$this->checkPassword($characterId, $password)) {
             return false;
         }
-        $_SESSION['nick'] = $nick;
+        $_SESSION['characterId'] = $characterId;
         return true;
     }
 }

--- a/src/Views/Editor.php
+++ b/src/Views/Editor.php
@@ -7,7 +7,7 @@ use Incertitude\SWLRP\Application;
 class Editor extends Profile {
     public function __construct(array $data, Application $application) {
         parent::__construct($data, $application);
-        $this->setRequestedName($application->getSession()->getNickLoggedIn());
+        $this->setRequestedId($application->getSession()->getCharacterId());
     }
     protected function getProfile(): array {
         return ['editMode' => true] + parent::getProfile();

--- a/src/Views/Front.php
+++ b/src/Views/Front.php
@@ -5,7 +5,7 @@ namespace Incertitude\SWLRP\Views;
 use Incertitude\SWLRP\Application;
 use Incertitude\SWLRP\LayoutView;
 use Incertitude\SWLRP\Session;
-use Incertitude\SWLRP\Exceptions\AutoLogin;
+use Incertitude\SWLRP\Exceptions\IsLoggedIn;
 
 class Front extends LayoutView {
     const MODEL_NAME = 'Account';
@@ -30,7 +30,7 @@ class Front extends LayoutView {
         } elseif (!$this->session->isLoggedIn($this->getData(0))) {
             $this->state = $this->getModel()->isRegistered($nick) ? self::STATE_LOGIN : self::STATE_REGISTER;
         } else {
-            throw new AutoLogin();
+            throw new IsLoggedIn();
         }
     }
     protected function getTitle(): string {

--- a/src/Views/Front.php
+++ b/src/Views/Front.php
@@ -6,7 +6,11 @@ use Incertitude\SWLRP\Application;
 use Incertitude\SWLRP\LayoutView;
 use Incertitude\SWLRP\Session;
 use Incertitude\SWLRP\Exceptions\IsLoggedIn;
+use Incertitude\SWLRP\Models\Account;
 
+/**
+ * @method Account getModel()
+ */
 class Front extends LayoutView {
     const MODEL_NAME = 'Account';
     const STATE_NOT_LOGGED_IN = 0;
@@ -24,11 +28,11 @@ class Front extends LayoutView {
     public function __construct(array $data, Application $application) {
         parent::__construct($data, $application);
         $this->session = $application->getSession();
-        $nick = $this->getData(0) ?: $this->session->getNickLoggedIn();
-        if (empty($nick)) {
+        $characterId = $this->getData(0) ?: $this->session->getCharacterId();
+        if (empty($characterId)) {
             $this->state = self::STATE_NOT_LOGGED_IN;
         } elseif (!$this->session->isLoggedIn($this->getData(0))) {
-            $this->state = $this->getModel()->isRegistered($nick) ? self::STATE_LOGIN : self::STATE_REGISTER;
+            $this->state = $this->getModel()->isRegistered($characterId) ? self::STATE_LOGIN : self::STATE_REGISTER;
         } else {
             throw new IsLoggedIn();
         }
@@ -37,6 +41,6 @@ class Front extends LayoutView {
         return self::STATES[$this->state][0];
     }
     protected function getContent(): string {
-        return $this->renderTemplate(self::STATES[$this->state][1]);
+        return $this->renderTemplate(self::STATES[$this->state][1], ['names' => $this->getNameData()]);
     }
 }

--- a/src/Views/Profile.php
+++ b/src/Views/Profile.php
@@ -13,24 +13,24 @@ abstract class Profile extends LayoutView {
     ];
     /** @var array */
     private $profile;
-    /** @var string */
-    private $requestedName;
+    /** @var int */
+    private $requestedId;
     protected function getTitle(): string {
         return $this->getProfile()['name'];
     }
     protected function getContent(): string {
         return $this->renderTemplate('profile', $this->getProfile());
     }
-    protected function setRequestedName(string $name) {
-        $this->requestedName = ucwords($name);
+    protected function setRequestedId(int $id) {
+        $this->requestedId = $id;
     }
-    protected function getRequestedName(): string {
-        return $this->requestedName;
+    protected function getRequestedId(): int {
+        return $this->requestedId;
     }
     protected function getProfile(): array {
         if (!isset($this->profile)) {
             $this->profile = [];
-            $data = $this->getModel()->load($this->getRequestedName());
+            $data = $this->getModel()->load($this->getRequestedId());
             if (!empty($data)) {
                 $this->loadProfileData($data);
             }
@@ -41,6 +41,7 @@ abstract class Profile extends LayoutView {
         return $this->profile;
     }
     protected function loadProfileData(array $data) {
+        $this->profile['nick'] = $data['nick'];
         $this->profile['name'] = $data['name'];
         $this->profile['structure'] = $this->getModel()->getMetadata();
         foreach ($this->profile['structure'] as &$profilePage) {

--- a/src/Views/Viewer.php
+++ b/src/Views/Viewer.php
@@ -8,7 +8,7 @@ use Incertitude\SWLRP\Exceptions\ProfileNotFound;
 class Viewer extends Profile {
     public function __construct(array $data, Application $application) {
         parent::__construct($data, $application);
-        $this->setRequestedName($this->getData(0));
+        $this->setRequestedId($this->getData(0));
     }
     protected function getTitle(): string {
         try {
@@ -25,7 +25,7 @@ class Viewer extends Profile {
         }
     }
     private function getFallbackName(\Exception $ex): string {
-        $name = $this->getRequestedName();
+        $name = $this->getData('nick');
         if (empty($name)) {
             throw $ex;
         }

--- a/templates/login.php
+++ b/templates/login.php
@@ -5,7 +5,6 @@
                 <h2>Please Log In to Edit</h2>
                 <form method="POST">
                     <label>Password: <input name="password" type="password" class="ui-widget-content ui-corner-all" /></label><br />
-                    <label><input name="autologin" type="checkbox" class="ui-widget-content ui-corner-all" /> Log in automatically</label><br />
                     <input type="submit" value="Log in" />
                 </form>
             </div>

--- a/templates/login.php
+++ b/templates/login.php
@@ -3,8 +3,11 @@
         <div class="column_one">
             <div class="column_text">
                 <h2>Please Log In to Edit</h2>
-                <form method="POST">
+                <form action="?" method="POST">
                     <label>Password: <input name="password" type="password" class="ui-widget-content ui-corner-all" /></label><br />
+<? foreach ($names as $key => $value): ?>
+                    <input type="hidden" name="<?=$key?>" value="<?=$value?>" />
+<? endforeach ?>
                     <input type="submit" value="Log in" />
                 </form>
             </div>

--- a/templates/profile.php
+++ b/templates/profile.php
@@ -35,6 +35,6 @@
     <div id="editbuttons">
         <button id="edit"></button>
     </div>
-<?=$this->renderTemplate('editorDialogs', ['name' => $this->getRequestedName()])?>
+<?=$this->renderTemplate('editorDialogs', ['name' => $this->getProfile()['nick']])?>
 <? endif ?>
 </div>

--- a/templates/register.php
+++ b/templates/register.php
@@ -3,7 +3,7 @@
         <div class="column_one">
             <div class="column_text">
                 <h2>Register Your Password</h2>
-                <form method="POST">
+                <form action="?" method="POST">
                     <p>
                         Please choose a password to secure your profile.<br />
                         You can leave this empty, but it is not recommended.<br />
@@ -11,6 +11,9 @@
                     </p>
                     <label>Password: <input name="password" type="password" class="ui-widget-content ui-corner-all" /></label><br />
                     <label>Repeat password: <input name="password" type="password" class="ui-widget-content ui-corner-all" /></label><br />
+<? foreach ($names as $key => $value): ?>
+                    <input type="hidden" name="<?=$key?>" value="<?=$value?>" />
+<? endforeach ?>
                     <input type="submit" value="Set password" />
                 </form>
             </div>

--- a/templates/register.php
+++ b/templates/register.php
@@ -11,7 +11,6 @@
                     </p>
                     <label>Password: <input name="password" type="password" class="ui-widget-content ui-corner-all" /></label><br />
                     <label>Repeat password: <input name="password" type="password" class="ui-widget-content ui-corner-all" /></label><br />
-                    <label><input name="autologin" type="checkbox" class="ui-widget-content ui-corner-all" /> Log in automatically</label><br />
                     <input type="submit" value="Set password" />
                 </form>
             </div>


### PR DESCRIPTION
### Resolves #19:
After this change, the profile will be bound to character ID rather than nickname, meaning that the profile won't disappear if someone changes their name.

### Resolves #9:
When logging in, and either name part is passed was a GET parameter, it will be automatically updated. Missing names will not be changed.
